### PR TITLE
PR for repo configurations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Claude bot is a required reviewer on every pull request.
+# Requires the Claude GitHub App to be installed on this repo:
+# https://github.com/apps/claude
+* @claude[bot]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+closes #
+
+## Summary
+
+
+## Changes
+
+-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Personal and Claude Code files - kept local, not published
+CLAUDE.md
+.claude/
+mynotes.md
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.Python
+*.egg-info/
+dist/
+build/
+.eggs/
+
+# uv
+.venv/
+.uv/
+
+# Testing & coverage
+.pytest_cache/
+.coverage
+htmlcov/
+coverage.xml
+
+# Mypy
+.mypy_cache/
+
+# Ruff
+.ruff_cache/
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
closes #1

## Summary
Add GitHub repo configuration: PR template, CODEOWNERS for Claude bot reviewer, and gitignore for local/private files.

## Changes
- `.github/pull_request_template.md` — auto-populates `closes #N` format on every new PR
- `.github/CODEOWNERS` — requests `claude[bot]` as required reviewer on all PRs
- `.gitignore` — excludes `CLAUDE.md`, `.claude/`, `mynotes.md`, and standard Python artifacts