### PR TITLE
PR for parser

### DIFF
--- a/reports/mixed_paths.rpt
+++ b/reports/mixed_paths.rpt
@@ -25,7 +25,7 @@ Path Type: max
     Delay      Time   Description
 -------------------------------------------------------------
     0.000    0.000    clock clk (rise edge)
-             12.000   data arrival 
+             12.000   data arrival time
 
     0.000    0.000    clock clk (rise edge)
              10.000   data required time

--- a/src/static_timing_analysis/timing_report.py
+++ b/src/static_timing_analysis/timing_report.py
@@ -1,0 +1,108 @@
+from collections.abc import Iterable
+from pathlib import Path
+
+from static_timing_analysis.timing_path import PathType, SlackStatus, TimingPath
+
+
+class TimingReport:
+
+    def __init__(self, paths: list[TimingPath]) -> None:
+        self.paths = paths
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "TimingReport":
+        with open(Path(path), encoding="utf-8", errors="replace") as fh:
+            return cls._parse_lines(fh)
+
+    @classmethod
+    def from_string(cls, text: str) -> "TimingReport":
+        return cls._parse_lines(text.replace("\r\n", "\n").splitlines())
+
+    @classmethod
+    def _parse_lines(cls, lines: Iterable[str]) -> "TimingReport":
+        paths: list[TimingPath] = []
+
+        startpoint: str | None = None
+        endpoint: str | None = None
+        path_group: str | None = None
+        path_type: str | None = None
+        arrival_time: float | None = None
+        required_time: float | None = None
+
+        for raw_line in lines:
+            line = raw_line.strip()
+
+            if line.startswith("Startpoint:"):
+                startpoint = line.split()[1]
+                endpoint = None
+                path_group = path_type = None
+                arrival_time = required_time = None
+                continue
+
+            if startpoint is None:
+                continue
+
+            if line.startswith("Endpoint:"):
+                endpoint = line.split()[1]
+                continue
+
+            if line.startswith("Path Group:"):
+                path_group = line.split("Path Group:")[1].strip()
+                continue
+
+            if line.startswith("Path Type:"):
+                path_type = line.split("Path Type:")[1].strip()
+                continue
+
+            tokens = line.split()
+
+            if len(tokens) == 4 and tokens[1] == "data" and tokens[2] == "required":
+                required_time = float(tokens[0])
+                continue
+
+            if len(tokens) == 4 and tokens[1] == "data" and tokens[2] == "arrival":
+                arrival_time = abs(float(tokens[0]))
+                continue
+
+            if (
+                len(tokens) == 3
+                and tokens[1] == "slack"
+                and startpoint is not None
+                and endpoint is not None
+                and path_group is not None
+                and path_type is not None
+                and arrival_time is not None
+                and required_time is not None
+            ):
+                slack = float(tokens[0])
+                status = SlackStatus(tokens[2].strip("()"))
+                paths.append(TimingPath(
+                    startpoint=startpoint,
+                    endpoint=endpoint,
+                    path_group=path_group,
+                    path_type=PathType(path_type),
+                    arrival_time=arrival_time,
+                    required_time=required_time,
+                    slack=slack,
+                    status=status,
+                ))
+                startpoint = endpoint = None
+                path_group = path_type = None
+                arrival_time = required_time = None
+
+        return cls(paths)
+
+    def filter(
+        self,
+        status: SlackStatus | None = None,
+        path_type: PathType | None = None,
+        group: str | None = None,
+    ) -> list[TimingPath]:
+        result = self.paths
+        if status is not None:
+            result = [p for p in result if p.status == status]
+        if path_type is not None:
+            result = [p for p in result if p.path_type == path_type]
+        if group is not None:
+            result = [p for p in result if p.path_group == group]
+        return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+from static_timing_analysis.timing_report import TimingReport
+
+
+@pytest.fixture(scope="session")
+def empty_report() -> TimingReport:
+    return TimingReport.from_file("reports/empty.rpt")
+
+
+@pytest.fixture(scope="session")
+def simple_met_report() -> TimingReport:
+    return TimingReport.from_file("reports/simple_met.rpt")
+
+
+@pytest.fixture(scope="session")
+def simple_violated_report() -> TimingReport:
+    return TimingReport.from_file("reports/simple_violated.rpt")
+
+
+@pytest.fixture(scope="session")
+def mixed_report() -> TimingReport:
+    return TimingReport.from_file("reports/mixed_paths.rpt")
+
+
+@pytest.fixture(scope="session")
+def full_report() -> TimingReport:
+    return TimingReport.from_file("reports/timing_full.rpt")

--- a/tests/test_timing_report.py
+++ b/tests/test_timing_report.py
@@ -1,0 +1,105 @@
+from static_timing_analysis.timing_path import PathType, SlackStatus
+from static_timing_analysis.timing_report import TimingReport
+
+
+class TestEmptyReport:
+    def test_no_paths(self, empty_report: TimingReport) -> None:
+        assert len(empty_report.paths) == 0
+
+
+class TestSimpleMetReport:
+    def test_one_path(self, simple_met_report: TimingReport) -> None:
+        assert len(simple_met_report.paths) == 1
+
+    def test_fields(self, simple_met_report: TimingReport) -> None:
+        path = simple_met_report.paths[0]
+        assert path.startpoint == "reg_a"
+        assert path.endpoint == "reg_b"
+        assert path.path_group == "clk"
+        assert path.path_type == PathType.MAX
+        assert path.arrival_time == 5.0
+        assert path.required_time == 10.0
+        assert path.slack == 5.0
+        assert path.status == SlackStatus.MET
+
+
+class TestSimpleViolatedReport:
+    def test_one_path(self, simple_violated_report: TimingReport) -> None:
+        assert len(simple_violated_report.paths) == 1
+
+    def test_status_and_slack(self, simple_violated_report: TimingReport) -> None:
+        path = simple_violated_report.paths[0]
+        assert path.status == SlackStatus.VIOLATED
+        assert path.slack == -5.0
+
+
+class TestMixedReport:
+    def test_four_paths(self, mixed_report: TimingReport) -> None:
+        assert len(mixed_report.paths) == 4
+
+    def test_startpoints(self, mixed_report: TimingReport) -> None:
+        startpoints = [p.startpoint for p in mixed_report.paths]
+        assert "reg_min_violated" in startpoints
+        assert "reg_max_violated" in startpoints
+        assert "reg_min_met" in startpoints
+        assert "reg_max_met" in startpoints
+
+    def test_groups(self, mixed_report: TimingReport) -> None:
+        groups = {p.path_group for p in mixed_report.paths}
+        assert groups == {"clk_group", "other_group"}
+
+    def test_statuses(self, mixed_report: TimingReport) -> None:
+        statuses = [p.status for p in mixed_report.paths]
+        assert statuses.count(SlackStatus.MET) == 2
+        assert statuses.count(SlackStatus.VIOLATED) == 2
+
+    def test_path_types(self, mixed_report: TimingReport) -> None:
+        types = [p.path_type for p in mixed_report.paths]
+        assert types.count(PathType.MIN) == 2
+        assert types.count(PathType.MAX) == 2
+
+
+class TestFullReport:
+    def test_path_count(self, full_report: TimingReport) -> None:
+        assert len(full_report.paths) == 102
+
+    def test_path_group(self, full_report: TimingReport) -> None:
+        groups = {p.path_group for p in full_report.paths}
+        assert groups == {"core_clock"}
+
+
+class TestFromString:
+    def test_matches_from_file(self, simple_met_report: TimingReport) -> None:
+        with open("reports/simple_met.rpt", encoding="utf-8") as f:
+            text = f.read()
+        report = TimingReport.from_string(text)
+        assert len(report.paths) == len(simple_met_report.paths)
+        assert report.paths[0].slack == simple_met_report.paths[0].slack
+
+
+class TestFilter:
+    def test_filter_by_status(self, mixed_report: TimingReport) -> None:
+        violated = mixed_report.filter(status=SlackStatus.VIOLATED)
+        assert len(violated) == 2
+        assert all(p.status == SlackStatus.VIOLATED for p in violated)
+
+    def test_filter_by_type(self, mixed_report: TimingReport) -> None:
+        max_paths = mixed_report.filter(path_type=PathType.MAX)
+        assert len(max_paths) == 2
+        assert all(p.path_type == PathType.MAX for p in max_paths)
+
+    def test_filter_by_group(self, mixed_report: TimingReport) -> None:
+        paths = mixed_report.filter(group="clk_group")
+        assert len(paths) == 2
+        assert all(p.path_group == "clk_group" for p in paths)
+
+    def test_combined_filter(self, mixed_report: TimingReport) -> None:
+        paths = mixed_report.filter(status=SlackStatus.VIOLATED, path_type=PathType.MIN)
+        assert len(paths) == 1
+        assert paths[0].startpoint == "reg_min_violated"
+
+    def test_no_filters_returns_all(self, mixed_report: TimingReport) -> None:
+        assert len(mixed_report.filter()) == 4
+
+    def test_filter_no_match(self, mixed_report: TimingReport) -> None:
+        assert mixed_report.filter(group="nonexistent") == []


### PR DESCRIPTION
closes #5

## Summary
Implement a single-pass state-machine parser for OpenROAD .rpt files, with a filter method and full test suite.

## Changes
- `src/static_timing_analysis/timing_report.py` — TimingReport with from_file, from_string, _parse_lines, and filter
- `tests/conftest.py` — session-scoped fixtures loading all 5 report fixtures
- `tests/test_timing_report.py` — 19 tests covering empty, simple, mixed, and full reports plus filter combinations
- `reports/mixed_paths.rpt` — fixed typo ("data arrival" → "data arrival time")